### PR TITLE
🐛 [fix] Dockerfile 및 CICD upload jar file 부분 수정

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -63,7 +63,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jar_files
-          path: build/libs/*.jar
+          path: |
+            $(ls -t build/libs/*.jar | head -n 1)
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:17-alpine
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
+RUN ls -al /app.jar
 ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]


### PR DESCRIPTION
## #️⃣ Issue Number
- close #93

## 📝 요약(Summary)
Github Actions 빌드 과정에서 build/libs 디렉토리 내 구버전 .jar 파일이 복사되는 문제를 수정완료.
최신 빌드된 .jar 파일만 Artifact로 업로드하도록 워크플로우를 수정.

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- 버그 수정

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
