### PR TITLE
Bug/#93

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -63,7 +63,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jar_files
-          path: build/libs/*.jar
+          path: |
+            $(ls -t build/libs/*.jar | head -n 1)
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -59,12 +59,15 @@ jobs:
           echo "Tests failed. Please check the test report/logs for details."
           exit 1
 
+      - name: Find latest jar file
+        id: find-jar
+        run: echo "LATEST_JAR=$(ls -t build/libs/*.jar | head -n 1)" >> $GITHUB_ENV
+
       - name: Upload jar file to Artifact
         uses: actions/upload-artifact@v4
         with:
           name: jar_files
-          path: |
-            $(ls -t build/libs/*.jar | head -n 1)
+          path: ${{ env.LATEST_JAR }}
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:17-alpine
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
+RUN ls -al /app.jar
 ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]


### PR DESCRIPTION
## #️⃣ Issue Number
- close #93

## 📝 요약(Summary)
- Github Actions 워크플로우에서 최신 JAR 파일만 업로드할 수 있도록 CI 스텝(`Find latest jar file`)을 추가했습니다.

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- CICD 개선
- 버그 수정

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
