### PR TITLE
🐛 [fix(ci)] CI/CD에서 bootJar 결과물 명시적으로 업로드하도록 수정

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -63,7 +63,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jar_files
-          path: build/libs/*.jar
+          path: |
+            $(ls -t build/libs/*.jar | head -n 1)
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Find latest jar file
         id: find-jar
-        run: echo "LATEST_JAR=$(ls -t build/libs/*.jar | head -n 1)" >> $GITHUB_ENV
+        run: echo "LATEST_JAR=$(find build/libs -type f -name '*.jar' ! -name '*plain*' | head -n 1)" >> $GITHUB_ENV
 
       - name: Upload jar file to Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -67,16 +67,16 @@ jobs:
           echo "Tests failed. Please check the test report/logs for details."
           exit 1
 
-      - name: Find latest jar file
-        id: find-jar
-        run: echo "LATEST_JAR=$(find build/libs -type f -name '*.jar' ! -name '*plain*' | head -n 1)" >> $GITHUB_ENV
+#      - name: Find latest jar file
+#        id: find-jar
+#        run: echo "LATEST_JAR=$(find build/libs -type f -name '*.jar' ! -name '*plain*' | head -n 1)" >> $GITHUB_ENV
 
 
       - name: Upload jar file to Artifact
         uses: actions/upload-artifact@v4
         with:
           name: jar_files
-          path: ${{ env.LATEST_JAR }}
+          path: build/libs/server-0.0.1-SNAPSHOT.jar
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -59,12 +59,15 @@ jobs:
           echo "Tests failed. Please check the test report/logs for details."
           exit 1
 
+      - name: Find latest jar file
+        id: find-jar
+        run: echo "LATEST_JAR=$(ls -t build/libs/*.jar | head -n 1)" >> $GITHUB_ENV
+
       - name: Upload jar file to Artifact
         uses: actions/upload-artifact@v4
         with:
           name: jar_files
-          path: |
-            $(ls -t build/libs/*.jar | head -n 1)
+          path: ${{ env.LATEST_JAR }}
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -37,17 +37,25 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+
+      - name: Set Spring Profile Based on Branch
+        id: set-profile
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            echo "SPRING_PROFILE=prod" >> $GITHUB_ENV
+          else
+            echo "SPRING_PROFILE=dev" >> $GITHUB_ENV
+          fi
+
       - name: Verify Backend_Config files
         run: ls -al Backend_Config
 
-      - name: Build and Test with Gradle Wrapper
-        env:
-          SPRING_PROFILES_ACTIVE: test
+      - name: Build with Gradle Wrapper
         run: |
-          echo "▶ Running Gradle build and test..."
-          ./gradlew --no-daemon clean build test \
-          -Dspring.profiles.active=test \
-          -Dspring.config.location=classpath:/,file:./Backend_Config/application-test.properties
+          echo "▶ Running Gradle bootJar with $SPRING_PROFILE profile..."
+          ./gradlew --no-daemon clean bootJar \
+          -Dspring.profiles.active=$SPRING_PROFILE \
+          -Dspring.config.location=classpath:/,file:./Backend_Config/application-$SPRING_PROFILE.properties
 
       - name: Show test results summary
         if: success()
@@ -69,7 +77,6 @@ jobs:
         with:
           name: jar_files
           path: ${{ env.LATEST_JAR }}
-
 
       - name: Upload Dockerfile to Artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM openjdk:17-alpine
-ARG JAR_FILE=build/libs/*.jar
+ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-RUN ls -al /app.jar
 ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:17-alpine
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
+RUN ls -al /app.jar
 ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -60,3 +60,7 @@ task copyYml(type: Copy){
 		into 'src/main/resources'
 	}
 }
+
+tasks.withType(Jar){
+	enabled = false
+}

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ task copyYml(type: Copy){
 	}
 }
 
-tasks.withType(Jar){
-	enabled = false
+tasks.named('jar') {
+	configure {
+		enabled = false
+	}
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- close #93

## 📝 요약(Summary)
- Github Actions 워크플로우에서 build/libs 디렉토리 내 jar 파일을 명확하게 지정하여 업로드하도록 수정.
- Find latest jar 스텝을 제거하고, 실행 가능한 bootJar 결과물만 복사하게 변경

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] CI/CD 개선

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
