### PR TITLE
🐛 [fix] 챗봇 응답 생성 - 새로운 대화인 경우의 기존 채팅 삭제 로직이 반영되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/going/server/domain/chatbot/dto/CreateChatbotRequestDto.java
+++ b/src/main/java/com/going/server/domain/chatbot/dto/CreateChatbotRequestDto.java
@@ -2,7 +2,6 @@ package com.going.server.domain.chatbot.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public class CreateChatbotRequestDto {

--- a/src/main/java/com/going/server/domain/chatbot/repository/ChattingRepository.java
+++ b/src/main/java/com/going/server/domain/chatbot/repository/ChattingRepository.java
@@ -11,13 +11,12 @@ import java.util.List;
 
 @Repository
 public interface ChattingRepository extends Neo4jRepository<Chatting, Long> {
-    // Graph로 모든 Chatting 삭제
     @Query("""
     MATCH (c:Chatting)-[:BELONGS_TO]->(g:Graph)
-    WHERE g = $graph
+    WHERE id(g) = $graphId
     DETACH DELETE c
     """)
-    void deleteByGraph(Graph graph);
+    void deleteByGraphId(Long graphId);
 
     // GraphId로 모든 Chatting 조회
     @Query("""
@@ -26,5 +25,4 @@ public interface ChattingRepository extends Neo4jRepository<Chatting, Long> {
     RETURN c ORDER BY c.createdAt
     """)
     List<Chatting> findAllByGraphId(@Param("graphId") Long graphId);
-
 }

--- a/src/main/java/com/going/server/domain/chatbot/service/ChatbotServiceImpl.java
+++ b/src/main/java/com/going/server/domain/chatbot/service/ChatbotServiceImpl.java
@@ -42,7 +42,7 @@ public class ChatbotServiceImpl implements ChatbotService {
         System.out.println("createChatbotRequestDto: "  + createChatbotRequestDto.getChatContent() + createChatbotRequestDto.isNewChat());
         // 새로운 대화인 경우 기존 채팅 삭제
         if (createChatbotRequestDto.isNewChat()) {
-            deletePreviousChat(graph);
+            deletePreviousChat(graphId);
         }
 
         // 기존 채팅 내역 조회
@@ -50,6 +50,7 @@ public class ChatbotServiceImpl implements ChatbotService {
 
         // 새로운 채팅
         String newChat = createChatbotRequestDto.getChatContent();
+
         // 새로운 채팅 repository에 저장
         Chatting chatting = Chatting.builder()
                 .graph(graph)
@@ -83,8 +84,8 @@ public class ChatbotServiceImpl implements ChatbotService {
     }
 
     // 기존 채팅 삭제 메서드
-    private void deletePreviousChat(Graph graph) {
-        chattingRepository.deleteByGraph(graph);
+    private void deletePreviousChat(Long graphId) {
+        chattingRepository.deleteByGraphId(graphId);
     }
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- close #150 

## 📝 요약(Summary)
1. **상황**
   * `isNewChat: true`를 줘도 삭제 로직이 동작하지 않음

2. **원인**
   * Jackson이 `isNewChat` → `newChat`으로 인식해 값이 무시됨
   * Cypher 쿼리에서 `g = $graph`는 동작하지 않음 (객체 비교 불가)

3. **해결**
   * `@JsonProperty("isNewChat")` 추가
   * `deleteByGraph(graph)` → `deleteByGraphId(graphId)`로 변경 후 `id(g) = $graphId` 사용

---

1. **상황**
   * `deleteByGraph(graph)` 메서드가 실행되었지만 채팅 노드가 삭제되지 않음

2. **원인**
   * Cypher 쿼리에서 `g = $graph`처럼 객체 자체를 비교하면 동작하지 않음

3. **해결**
   * `id(g) = $graphId`로 ID 기반 비교로 수정하여 정상 작동하도록 변경


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일/폴더 수정 혹은 삭제

## 📸스크린샷
<img width="295" alt="image" src="https://github.com/user-attachments/assets/498ce742-96f2-4353-92e8-b51f6c3600b8" />


수정 후 삭제 로직 제대로 작동합니다.

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
