### PR TITLE
🐛 [fix] openai 이미지 생성의 지원되는 사이즈 목록 중 하나 채택

### DIFF
--- a/src/main/java/com/going/server/domain/quiz/generate/PictureQuizGenerator.java
+++ b/src/main/java/com/going/server/domain/quiz/generate/PictureQuizGenerator.java
@@ -64,7 +64,7 @@ public class PictureQuizGenerator implements QuizGenerator<PictureQuizDto> {
                 prompt,
                 "dall-e-3",
                 "vivid",
-                "900x900",
+                "512x512",
                 1);
         String imageUrl = imageCreateService.generatePicture(requestDto);
 


### PR DESCRIPTION

## #️⃣ Issue Number

## 📝 요약(Summary)
900 x 900 은 지원되지 않음. 지원되는 512 x 512로 수정함


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일/폴더 수정 혹은 삭제

## 📸스크린샷

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
