### PR TITLE
⚡️ [Perf] GraphRAG 검색 쿼리 생성 시 복합 개념 분리 검색 유도

### DIFF
--- a/src/main/java/com/going/server/domain/rag/service/CypherQueryGenerator.java
+++ b/src/main/java/com/going/server/domain/rag/service/CypherQueryGenerator.java
@@ -14,32 +14,38 @@ public class CypherQueryGenerator {
 
     public String generate(String userQuestion) {
         String prompt = """
-            당신은 Neo4j 그래프 데이터베이스에서 정보를 추출하기 위한 Cypher 쿼리를 생성하는 AI입니다.
-            
-            - 주어진 질문에서 핵심 개념과 연관된 개념들을 찾아야 합니다.
-            - 질문에 포함된 키워드와 의미적으로 밀접한 노드 쌍 간의 관계(triple)를 추출해야 합니다.
-            - 반드시 관계 중심 구조 (시작 노드, 관계 라벨, 도착 노드)를 반환하는 Cypher 쿼리를 작성하세요.
-            - 관계나 노드에 포함된 설명 문장 중 하나를 함께 반환하세요. (r.sentence → 없으면 a.includeSentence → 없으면 b.includeSentence 순으로)
-            - 반환 항목은 다음과 같아야 합니다:
-              sourceLabel, relationLabel, targetLabel, sentence, nodeLabel
-            - 코드는 반드시 Cypher 쿼리 한 줄만 출력하며, 코드블록이나 설명은 포함하지 마세요.
+        당신은 Neo4j 그래프 데이터베이스에서 정보를 추출하는 Cypher 쿼리를 생성하는 AI입니다.
+        
+        - 사용자 질문에 포함된 복합 명사(예: "지구형 행성")는 의미 단위로 분리해서,  
+          해당 단어 각각이 포함된 노드도 함께 탐색할 수 있도록 쿼리를 작성하세요.
+        - 예를 들어 "지구형 행성과 관련된 개념"이라면,
+          "지구형", "행성", "지구형 행성" 모두를 쿼리 조건에 포함해야 합니다.
+        - 관계(triple)는 (시작 노드)-[관계]->(도착 노드) 형식으로 추출하세요.
+        - 설명 문장도 함께 조회하세요. (r.sentence → a.includeSentence → b.includeSentence)
+        - 반환 항목:
+          sourceLabel, relationLabel, targetLabel, sentence, nodeLabel
+        - 코드는 Cypher 한 줄만 출력하며, 설명이나 코드블록 없이 작성하세요.
+        - LIMIT은 5로 설정하세요.
+        
+        예시 질문: 지구형 행성과 관련된 개념들을 알려줘  
+        →  
+        MATCH (a:GraphNode)-[r:RELATED]-(b:GraphNode)  
+        WHERE
+          toLower(a.label) =~ '.*지구형.*' OR toLower(b.label) =~ '.*지구형.*' OR
+          toLower(a.label) =~ '.*행성.*' OR toLower(b.label) =~ '.*행성.*' OR
+          toLower(a.label) =~ '.*지구형 행성.*' OR toLower(b.label) =~ '.*지구형 행성.*'  
+        RETURN  
+          a.label AS sourceLabel,  
+          r.label AS relationLabel,  
+          b.label AS targetLabel,  
+          COALESCE(r.sentence, a.includeSentence, b.includeSentence, "") AS sentence,  
+          a.label AS nodeLabel  
+        LIMIT 5
+        
+        질문: "%s"
+        →
+        """.formatted(userQuestion);
 
-            예시:
-            질문: "고래와 관련된 개념들을 알려줘"
-            →
-            MATCH (a:GraphNode)-[r:RELATED]-(b:GraphNode)
-            WHERE toLower(a.label) CONTAINS toLower('고래') OR toLower(b.label) CONTAINS toLower('고래')
-            RETURN 
-              a.label AS sourceLabel,
-              r.label AS relationLabel,
-              b.label AS targetLabel,
-              COALESCE(r.sentence, a.includeSentence, b.includeSentence, "") AS sentence,
-              a.label AS nodeLabel
-            LIMIT 15
-
-            질문: "%s"
-            →
-            """.formatted(userQuestion);
 
         return openAIService.getCompletionResponse(
                 List.of(new ChatMessage("user", prompt)),


### PR DESCRIPTION
## #️⃣ Issue Number
- close #200 

## 📝 요약(Summary)
복합 개념 분리 검색 유도
ex. 지구형 행성 인 경우,
지구, 행성, 지구형 행성로 검색하도록 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일/폴더 수정 혹은 삭제
- [x] 성능개선

## 📸스크린샷

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
